### PR TITLE
BE l Create `defaultTags` query type. Add default boolean column to Tags table

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -17,5 +17,11 @@ module Types
         raise GraphQL::ExecutionError, "User not found"
       end
     end
+
+    field :default_tags, [Types::TagType], null: false
+
+    def default_tags
+      Tag.default_tags
+    end
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -5,4 +5,9 @@ class Tag < ApplicationRecord
 
   has_many :dream_tags
   has_many :dreams, through: :dream_tags
+
+  def self.default_tags
+    where(default: true)
+  end
+  
 end

--- a/db/migrate/20230517230450_add_column_default_to_tags.rb
+++ b/db/migrate/20230517230450_add_column_default_to_tags.rb
@@ -1,0 +1,5 @@
+class AddColumnDefaultToTags < ActiveRecord::Migration[7.0]
+  def change
+    add_column :tags, :default, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_12_212336) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_17_230450) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -53,6 +53,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212336) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "default", default: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,5 @@
 ActiveRecord::Base.connection.tables.each do |table|
+  next if table == 'schema_migrations'
   ActiveRecord::Base.connection.execute("TRUNCATE #{table} RESTART IDENTITY CASCADE")
 end
 
@@ -16,4 +17,39 @@ end
       DreamTag.create(tag_id: tag.id, dream_id: dream.id)
     end
   end
+end
+
+default_tags = [
+  "Flying",
+  "Falling",
+  "Chased",
+  "Lost",
+  "Late",
+  "Losing teeth",
+  "Naked",
+  "School",
+  "Work",
+  "Car accident",
+  "Fire",
+  "Water",
+  "Tornadoes",
+  "Meeting someone famous",
+  "Deceased loved one",
+  "Strange place",
+  "Nature",
+  "Science Fiction",
+  "Travel",
+  "Relationships",
+  "Self-discovery",
+  "Nightmares",
+  "Night Terrors",
+  "Food",
+  "Music",
+  "Supernatural",
+  "Sleep Paralysis",
+  "Dreams within Dreams"
+]
+
+default_tags.each do |tag|
+  Tag.create(name: tag, default: true)
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -11,4 +11,20 @@ RSpec.describe Tag, type: :model do
     it { should have_many :dream_tags }
     it { should have_many(:dreams).through(:dream_tags) }
   end
+
+  describe 'class methods' do
+    describe '.default_tags' do
+      it 'returns an array of default tags' do
+        happy = Tag.create(name: 'happy', default: true)
+        sad = Tag.create(name: 'sad', default: true)
+        angry = Tag.create(name: 'angry', default: true)
+
+        melancholy = Tag.create(name: 'melancholy')
+        somber = Tag.create(name: 'somber')
+
+        expect(Tag.default_tags).to eq([happy, sad, angry])
+        expect(Tag.default_tags).to_not include(melancholy, somber)
+      end
+    end
+  end
 end

--- a/spec/requests/mutations/dreams/tags/delete_dream_tag_spec.rb
+++ b/spec/requests/mutations/dreams/tags/delete_dream_tag_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe DreamTag, type: :request do
 
       expect(DreamTag.count).to eq(0)
       expect(deleted_dream_tag.keys).to eq([:id])
-      expect(deleted_dream_tag[:id].to_i).to eq(tag.id)
+      expect(deleted_dream_tag[:id].to_i).to eq(dream_tag.id)
     end
    end
   end

--- a/spec/requests/queries/tags/default_tags_spec.rb
+++ b/spec/requests/queries/tags/default_tags_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Tag, type: :request do
+  describe 'Get all default tags' do
+    context 'when successful' do
+      it 'returns all default tags' do
+        happy = Tag.create(name: 'happy', default: true)
+        sad = Tag.create(name: 'sad', default: true)
+        angry = Tag.create(name: 'angry', default: true)
+
+        melancholy = Tag.create(name: 'melancholy')
+        somber = Tag.create(name: 'somber')
+
+        post '/graphql', params: { query: query_default_tags }
+
+        tags_response = JSON.parse(response.body, symbolize_names: true)
+        tags_data = tags_response[:data][:defaultTags]
+
+        expect(tags_data).to be_an(Array)
+        expect(tags_data.count).to eq(3)
+
+        expect(tags_data.first.keys).to eq(%i[id name])
+        expect(tags_data.first[:id]).to eq(happy.id.to_s)
+        expect(tags_data.first[:name]).to eq(happy.name)
+
+        expect(tags_data.second.keys).to eq(%i[id name])
+        expect(tags_data.second[:id]).to eq(sad.id.to_s)
+        expect(tags_data.second[:name]).to eq(sad.name)
+
+        expect(tags_data.third.keys).to eq(%i[id name])
+        expect(tags_data.third[:id]).to eq(angry.id.to_s)
+        expect(tags_data.third[:name]).to eq(angry.name)
+
+        expect(tags_data).to_not include(melancholy, somber)
+      end
+
+      def query_default_tags
+        <<~GQL
+          query{
+            defaultTags{
+              id
+              name
+            }
+          }
+        GQL
+      end
+    end
+  end
+end


### PR DESCRIPTION
Description of Changes:
- Creates `defaultTags` query type, `.default_tags` class method, add default boolean column to Tags table

Checks
Tests Written ? [x]
Tests Passing [x]
Code Will Run Locally on Postman [x]

Helpful Screenshots/Video Description:

Which Project Story Does This Close?
Closes #51 

Co-Authors: Kassandra Leyba
