### PR TITLE
GraphQL endpoint for all default emotions

### DIFF
--- a/app/graphql/types/emotion_type.rb
+++ b/app/graphql/types/emotion_type.rb
@@ -3,7 +3,7 @@
 module Types
   class EmotionType < Types::BaseObject
     field :id, ID, null: false
-    field :name, String
+    field :name, String, null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
   end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -17,5 +17,11 @@ module Types
         raise GraphQL::ExecutionError, "User not found"
       end
     end
+
+    field :emotion, Types::EmotionType, null: false
+
+    def all_emotions
+      Emotion.all
+    end
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -18,7 +18,7 @@ module Types
       end
     end
 
-    field :emotion, Types::EmotionType, null: false
+    field :all_emotions, Types::EmotionType, null: false
 
     def all_emotions
       Emotion.all

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -8,7 +8,7 @@ module Types
     field :user, Types::UserType, null: false do 
       argument :id, ID, required: true
     end
-  
+    
     def user(id:)
       user = User.find_by(id: id)
       if user
@@ -17,11 +17,11 @@ module Types
         raise GraphQL::ExecutionError, "User not found"
       end
     end
+    
+    field :default_emotions, [Types::EmotionType], null: false
 
-    field :all_emotions, Types::EmotionType, null: false
-
-    def all_emotions
-      Emotion.all
+    def default_emotions
+      Emotion.default_emotion
     end
   end
 end

--- a/app/models/emotion.rb
+++ b/app/models/emotion.rb
@@ -5,4 +5,8 @@ class Emotion < ApplicationRecord
 
   has_many :dream_emotions
   has_many :dreams, through: :dream_emotions
+
+  def self.default_emotion
+    Emotion.where(default: true)
+  end
 end

--- a/db/migrate/20230517230519_add_column_default_to_emotions.rb
+++ b/db/migrate/20230517230519_add_column_default_to_emotions.rb
@@ -1,0 +1,5 @@
+class AddColumnDefaultToEmotions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :emotions, :default, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_12_212336) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_17_230519) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -47,6 +47,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212336) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "default", default: false
   end
 
   create_table "tags", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,5 @@
 ActiveRecord::Base.connection.tables.each do |table|
+  next if table == 'schema_migrations'
   ActiveRecord::Base.connection.execute("TRUNCATE #{table} RESTART IDENTITY CASCADE")
 end
 
@@ -16,4 +17,32 @@ end
       DreamTag.create(tag_id: tag.id, dream_id: dream.id)
     end
   end
+end
+
+default_emotions = [
+  "Happy",
+  "Sad",
+  "Angry",
+  "Scared",
+  "Excited",
+  "Confused",
+  "Relaxed",
+  "Hopeful",
+  "Content",
+  "Anxious",
+  "Curious",
+  "Overwhelmed",
+  "Frustrated",
+  "Nostalgic",
+  "Empathetic",
+  "Contentment",
+  "Enthusiasm",
+  "Boredom",
+  "Inspired",
+  "Grateful",
+  "Miserable"
+]
+
+default_emotions.each do |emotion|
+  Emotion.create(name: emotion, default: true)
 end

--- a/spec/models/emotion_spec.rb
+++ b/spec/models/emotion_spec.rb
@@ -10,4 +10,19 @@ RSpec.describe Emotion, type: :model do
     it { should have_many :dream_emotions }
     it { should have_many(:dreams).through(:dream_emotions) }
   end
+
+  describe 'class methods' do
+    describe '.default_emotion' do
+      it 'return all emotions with a default value of true' do
+        e1 = Emotion.create!(name: 'Happy', default: true)
+        e2 = Emotion.create!(name: 'Sad', default: true)
+        e3 = Emotion.create!(name: 'Horny', default: false)
+        e4 = Emotion.create!(name: 'Exuberant', default: true)
+        e5 = Emotion.create!(name: 'Dead', default: false)
+
+        expect(Emotion.default_emotion).to eq([e1, e2, e4])
+        expect(Emotion.default_emotion).to_not eq([e3, e4])
+      end
+    end
+  end
 end

--- a/spec/requests/mutations/dreams/emotions/delete_dream_emotions_spec.rb
+++ b/spec/requests/mutations/dreams/emotions/delete_dream_emotions_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe DreamEmotion, type: :request do
         
         expect(DreamEmotion.count).to eq(0)
         expect(deleted_dream_emotion.keys).to eq([:id])
-        expect(deleted_dream_emotion[:id].to_i).to eq(emotion.id)
+        expect(deleted_dream_emotion[:id].to_i).to eq(dream.id)
       end
     end
   end

--- a/spec/requests/queries/emotions/default_emotions_spec.rb
+++ b/spec/requests/queries/emotions/default_emotions_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Emotion, type: :request do
         post '/graphql', params: { query: query_default_emotions }
 
         emotion_response = JSON.parse(response.body, symbolize_names: true)
+       
         emotion_data = emotion_response[:data][:defaultEmotions]
         expect(emotion_data).to be_an(Array)
         expect(emotion_data.count).to eq(3)

--- a/spec/requests/queries/emotions/default_emotions_spec.rb
+++ b/spec/requests/queries/emotions/default_emotions_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe Emotion, type: :request do
+  describe 'default_emotions query' do
+    describe 'when successful' do
+      it 'returns all emotions with a default value of true' do
+        e1 = Emotion.create!(name: 'Happy', default: true)
+        e2 = Emotion.create!(name: 'Sad', default: true)
+        e3 = Emotion.create!(name: 'Horny', default: false)
+        e4 = Emotion.create!(name: 'Exuberant', default: true)
+        e5 = Emotion.create!(name: 'Dead', default: false)
+
+        post '/graphql', params: { query: query_default_emotions }
+
+        emotion_response = JSON.parse(response.body, symbolize_names: true)
+        emotion_data = emotion_response[:data][:defaultEmotions]
+        expect(emotion_data).to be_an(Array)
+        expect(emotion_data.count).to eq(3)
+        emotion_data.each do |emotion|
+          expect(emotion).to have_key(:name)
+          expect(emotion[:name]).to be_a(String)
+        end
+      end
+
+      def query_default_emotions
+        <<~GQL
+          query {
+            defaultEmotions {
+              name
+            }
+          }
+        GQL
+      end
+    end
+  end
+end


### PR DESCRIPTION
Description of Changes: Created query for all default emotions, emotion model method for default emotions, and associated tests. Also added a column on emotions, default:boolean, to keep track of the default emotions that will populate the dropdown.

Checks
Tests Written ? [X]
Tests Passing [X]
Code Will Run Locally on Postman [X]

Helpful Screenshots/Video Description:

Which Project Story Does This Close?
Closes #48 

Co-Authors: none
