### PR TITLE
skip truncating ar internal metadata in seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,6 @@
 ActiveRecord::Base.connection.tables.each do |table|
   next if table == 'schema_migrations'
+  next if table == 'ar_internal_metadata'
   ActiveRecord::Base.connection.execute("TRUNCATE #{table} RESTART IDENTITY CASCADE")
 end
 


### PR DESCRIPTION
Description of Changes: One more database patch. We were dropping a table called AR_INTERNAL_METADATA, which was important, it turns out. 

Checks
Tests Written ? [n/a]
Tests Passing [x]
Code Will Run Locally on Postman [x]

